### PR TITLE
Pass version number from conda to setuptools_scm

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{version}}
   script: python -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools_scm
   run:
     - python >=3.6
     - cartopy <0.20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: python
   number: 0
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{version}}
   script: python -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   noarch: python
   number: 1
   script_env:
-    - SETUPTOOLS_SCM_PRETEND_VERSION={{version}}
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: python -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
Setuptools configuration in [metoppv/improver](https://github.com/metoppv/improver) (eg. setup.cfg, setup.py, pyproject.toml) uses [setuptools_scm](https://github.com/pypa/setuptools_scm/) to automatically determine the version number from git rather than specifying the version number in a file and manually incrementing that file as part of creating a release.
However, the conda recipe in this repository retrieves a .tar.gz release/tag file from github, and that tar files doesn't contain git metadata (eg. the `.git` directory) to determine the version.

Currently, this lack of version information results in the conda package having the correct version (such as 1.0.4), but the underlying installation into the `lib/python3.N/site-packages` directory having an unknown/incorrect version number (seems to always be 0.0.0). This is visible in improver-feedstock build logs, [such as for 1.0.4](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=443141&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=793).

In this situation, the [conda forge knowledge base](https://conda-forge.org/docs/maintainer/knowledge_base.html#using-setuptools-scm) recommends use of `SETUPTOOLS_SCM_PRETEND_VERSION` environment variable to pass the version number from the conda recipe through to setuptools_scm and setuptools, resulting in a consistent version number between conda and setuptools.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
